### PR TITLE
update logging

### DIFF
--- a/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -182,6 +182,7 @@ bool CIRCDDBGatewayAppD::init()
 
 		wxLog* log = new CLogger(m_logDir, logBaseName);
 		wxLog::SetActiveTarget(log);
+		wxLog::SetVerbose();
 	} else {
 		new wxLogNull;
 	}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -405,6 +405,7 @@ void CIRCDDBGatewayThread::run()
 				}
 			}
 
+			wxLog::FlushActive();
 			::wxMilliSleep(TIME_PER_TIC_MS);
 		}
 	}


### PR DESCRIPTION
 * aktivate verbose mode
    verbose messages are logged as the normal ones instead of being silently dropped
 * wxLogXXX from threads
    only the GUI wxApp called wxLog::FlushActive() in idle time. wxAppConsole doesn't
    show LogMessages from Threads.