### PR TITLE
Revert log file naming

### DIFF
--- a/Common/Logger.cpp
+++ b/Common/Logger.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2002,2003,2009,2011,2012,2018 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2002,2003,2009,2011,2012 by Jonathan Naylor G4KLX
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -19,20 +19,17 @@
 #include "Logger.h"
 
 CLogger::CLogger(const wxString& directory, const wxString& name) :
-#if(defined(__WINDOWS__))
-m_day(0),
-#endif
 wxLog(),
 m_name(name),
 m_file(NULL),
-m_fileName()
+m_fileName(),
+m_day(0)
 {
 	m_file = new wxFFile;
 
 	m_fileName.SetPath(directory);
 	m_fileName.SetExt(wxT("log"));
 
-#if(defined(__WINDOWS__))
 	time_t timestamp;
 	::time(&timestamp);
 	struct tm* tm = ::gmtime(&timestamp);
@@ -42,9 +39,6 @@ m_fileName()
 
 	m_day = tm->tm_yday;
 	m_fileName.SetName(text);
-#else
-	m_fileName.SetName(m_name);
-#endif
 
 	bool ret = m_file->Open(m_fileName.GetFullPath(), wxT("a+t"));
 	if (!ret) {
@@ -61,10 +55,11 @@ CLogger::~CLogger()
 	delete m_file;
 }
 
-void CLogger::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info)
+void CLogger::DoLog(wxLogLevel level, const wxChar* msg, time_t timestamp)
 {
 	wxASSERT(m_file != NULL);
 	wxASSERT(m_file->IsOpened());
+	wxASSERT(msg != NULL);
 
 	wxString letter;
 
@@ -80,23 +75,23 @@ void CLogger::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogReco
 		default:               letter = wxT("U"); break;
 	}
 
-	struct tm* tm = ::gmtime(&info.timestamp);
+	struct tm* tm = ::gmtime(&timestamp);
 
 	wxString message;
-	message.Printf(wxT("%s: %04d-%02d-%02d %02d:%02d:%02d: %s\n"), letter.c_str(), tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, msg.c_str());
+	message.Printf(wxT("%s: %04d-%02d-%02d %02d:%02d:%02d: %s\n"), letter.c_str(), tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, msg);
 
-	logString(message, info.timestamp);
+	DoLogString(message.c_str(), timestamp);
 
 	if (level == wxLOG_FatalError)
 		::abort();
 }
 
-void CLogger::logString(const wxString& msg, time_t timestamp)
+void CLogger::DoLogString(const wxChar* msg, time_t timestamp)
 {
 	wxASSERT(m_file != NULL);
 	wxASSERT(m_file->IsOpened());
+	wxASSERT(msg != NULL);
 
-#if(defined(__WINDOWS__))
 	struct tm* tm = ::gmtime(&timestamp);
 
 	int day = tm->tm_yday;
@@ -115,8 +110,8 @@ void CLogger::logString(const wxString& msg, time_t timestamp)
 			return;
 		}
 	}
-#endif
 
-	m_file->Write(msg);
+	m_file->Write(wxString(msg));
 	m_file->Flush();
 }
+

--- a/Common/Logger.h
+++ b/Common/Logger.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2002,2003,2009,2011,2012,2018 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2002,2003,2009,2011,2012 by Jonathan Naylor G4KLX
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -22,24 +22,21 @@
 #include <wx/wx.h>
 #include <wx/ffile.h>
 #include <wx/filename.h>
-#include <wx/log.h>
 
 class CLogger : public wxLog {
 public:
 	CLogger(const wxString& directory, const wxString& name);
 	virtual ~CLogger();
 
-	virtual void DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info);
+	virtual void DoLog(wxLogLevel level, const wxChar* msg, time_t timestamp);
+	virtual void DoLogString(const wxChar* msg, time_t timestamp);
 
 private:
 	wxString   m_name;
 	wxFFile*   m_file;
 	wxFileName m_fileName;
-#if(defined(__WINDOWS__))
 	int        m_day;
-#endif
-
-	void logString(const wxString& msg, time_t timestamp);
 };
 
 #endif
+

--- a/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -48,7 +48,7 @@ const wxChar*    LOGDIR_OPTION = wxT("logdir");
 const wxChar*   CONFDIR_OPTION = wxT("confdir");
 const wxChar*    DAEMON_SWITCH = wxT("daemon");
 
-const wxString LOG_BASE_NAME    = wxT("ircddbgatewayd");
+const wxString LOG_BASE_NAME    = wxT("ircDDBGateway");
 
 static CIRCDDBGatewayAppD* m_gateway = NULL;
 


### PR DESCRIPTION
Revert log file naming introduced with [this commit](https://github.com/dl5di/OpenDV/tree/559c33043a0dd360d1f32b97337daaafc7a90007)

Now log file has date in name, like it was prior to this commit.