### PR TITLE
G2 Nat Traversal improvements

### DIFF
--- a/Common/CacheManager.cpp
+++ b/Common/CacheManager.cpp
@@ -92,11 +92,6 @@ CRepeaterData* CCacheManager::findRepeater(const wxString& repeater)
 
 void CCacheManager::updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, const wxString& timestamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
-	updateUser(user, repeater, gateway, address, G2_DV_PORT, true, timestamp, protocol, addrLock, protoLock);
-}
-
-void CCacheManager::updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, const wxString& timestamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
-{
 	wxMutexLocker locker(m_mutex);
 
 	wxString repeater7 = repeater.Left(LONG_CALLSIGN_LENGTH - 1U);
@@ -108,15 +103,10 @@ void CCacheManager::updateUser(const wxString& user, const wxString& repeater, c
 	if (!repeater7.IsSameAs(gateway7))
 		m_repeaterCache.update(repeater, gateway);
 
-	updateGateway(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
+	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
 }
 
 void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
-{
-	updateRepeater(repeater, gateway, address, G2_DV_PORT, true, protocol, addrLock, protoLock);
-}
-
-void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
 	wxMutexLocker locker(m_mutex);
 
@@ -127,24 +117,17 @@ void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gat
 	if (!repeater7.IsSameAs(gateway7))
 		m_repeaterCache.update(repeater, gateway);
 
-	updateGateway(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
+	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
 }
 
 void CCacheManager::updateGateway(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
-	updateGateway(gateway, address, G2_DV_PORT, true, protocol, addrLock, protoLock);
-}
-
-void CCacheManager::updateGateway(const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
-{
 	wxMutexLocker locker(m_mutex);
 
-	m_gatewayCache.update(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
+	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
 }
 
-void CCacheManager::updateGatewayG2(const wxString& gateway, const wxString& address, unsigned int g2Port)
+void CCacheManager::updateGatewayG2(const wxString& gateway, const in_addr& address, unsigned int g2Port)
 {
-	CGatewayRecord* gr = m_gatewayCache.find(gateway);
-	DSTAR_PROTOCOL protocol = gr != NULL? gr->getProtocol() : DP_UNKNOWN;
-	updateGateway(gateway, address, g2Port, false, protocol, false, false);
+	m_gatewayCache.updateG2(gateway, address, g2Port);
 }

--- a/Common/CacheManager.cpp
+++ b/Common/CacheManager.cpp
@@ -65,7 +65,7 @@ CGatewayData* CCacheManager::findGateway(const wxString& gateway)
 	if (gr == NULL)
 		return NULL;
 
-	return new CGatewayData(gateway, gr->getAddress(), gr->getProtocol());
+	return new CGatewayData(gateway, gr->getAddress(), gr->getProtocol(), gr->getG2Port());
 }
 
 CRepeaterData* CCacheManager::findRepeater(const wxString& repeater)
@@ -87,7 +87,7 @@ CRepeaterData* CCacheManager::findRepeater(const wxString& repeater)
 	if (gr == NULL)
 		return NULL;
 
-	return new CRepeaterData(repeater, gr->getGateway(), gr->getAddress(), gr->getProtocol());
+	return new CRepeaterData(repeater, gr->getGateway(), gr->getAddress(), gr->getProtocol(), gr->getG2Port());
 }
 
 void CCacheManager::updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, const wxString& timestamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)

--- a/Common/CacheManager.cpp
+++ b/Common/CacheManager.cpp
@@ -92,6 +92,11 @@ CRepeaterData* CCacheManager::findRepeater(const wxString& repeater)
 
 void CCacheManager::updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, const wxString& timestamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
+	updateUser(user, repeater, gateway, address, G2_DV_PORT, true, timestamp, protocol, addrLock, protoLock);
+}
+
+void CCacheManager::updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, const wxString& timestamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+{
 	wxMutexLocker locker(m_mutex);
 
 	wxString repeater7 = repeater.Left(LONG_CALLSIGN_LENGTH - 1U);
@@ -103,10 +108,15 @@ void CCacheManager::updateUser(const wxString& user, const wxString& repeater, c
 	if (!repeater7.IsSameAs(gateway7))
 		m_repeaterCache.update(repeater, gateway);
 
-	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
+	updateGateway(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
 }
 
 void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+{
+	updateRepeater(repeater, gateway, address, G2_DV_PORT, true, protocol, addrLock, protoLock);
+}
+
+void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
 	wxMutexLocker locker(m_mutex);
 
@@ -117,12 +127,24 @@ void CCacheManager::updateRepeater(const wxString& repeater, const wxString& gat
 	if (!repeater7.IsSameAs(gateway7))
 		m_repeaterCache.update(repeater, gateway);
 
-	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
+	updateGateway(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
 }
 
 void CCacheManager::updateGateway(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
+	updateGateway(gateway, address, G2_DV_PORT, true, protocol, addrLock, protoLock);
+}
+
+void CCacheManager::updateGateway(const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+{
 	wxMutexLocker locker(m_mutex);
 
-	m_gatewayCache.update(gateway, address, protocol, addrLock, protoLock);
+	m_gatewayCache.update(gateway, address, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
+}
+
+void CCacheManager::updateGatewayG2(const wxString& gateway, const wxString& address, unsigned int g2Port)
+{
+	CGatewayRecord* gr = m_gatewayCache.find(gateway);
+	DSTAR_PROTOCOL protocol = gr != NULL? gr->getProtocol() : DP_UNKNOWN;
+	updateGateway(gateway, address, g2Port, false, protocol, false, false);
 }

--- a/Common/CacheManager.cpp
+++ b/Common/CacheManager.cpp
@@ -54,7 +54,7 @@ CUserData* CCacheManager::findUser(const wxString& user)
 	if (gr == NULL)
 		return NULL;
 
-	return new CUserData(user, ur->getRepeater(), gr->getGateway(), gr->getAddress());
+	return new CUserData(user, ur->getRepeater(), gr->getGateway(), gr->getAddress(), gr->getG2Port());
 }
 
 CGatewayData* CCacheManager::findGateway(const wxString& gateway)

--- a/Common/CacheManager.h
+++ b/Common/CacheManager.h
@@ -33,11 +33,12 @@
 
 class CUserData {
 public:
-	CUserData(const wxString& user, const wxString& repeater, const wxString& gateway, in_addr address) :
+	CUserData(const wxString& user, const wxString& repeater, const wxString& gateway, in_addr address, unsigned int g2Port) :
 	m_user(user),
 	m_repeater(repeater),
 	m_gateway(gateway),
-	m_address(address)
+	m_address(address),
+	m_g2Port(g2Port)
 	{
 	}
 
@@ -61,11 +62,17 @@ public:
 		return m_address;
 	}
 
+	unsigned int getG2Port() const
+	{
+		return m_g2Port;
+	}
+
 private:
 	wxString m_user;
 	wxString m_repeater;
 	wxString m_gateway;
 	in_addr  m_address;
+	unsigned int m_g2Port;
 };
 
 class CRepeaterData {

--- a/Common/CacheManager.h
+++ b/Common/CacheManager.h
@@ -146,9 +146,14 @@ public:
 
 	void updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, const wxString& timeStamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
 	void updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
-	void updateGateway(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void updateGateway(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol,bool addrLock, bool protoLock);
+	void updateGatewayG2(const wxString& gateway, const wxString& address, unsigned int g2Port);
 
 private:
+	void updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, const wxString& timeStamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void updateGateway(const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol,bool addrLock, bool protoLock);
+
 	wxMutex        m_mutex;
 	CUserCache     m_userCache;
 	CGatewayCache  m_gatewayCache;

--- a/Common/CacheManager.h
+++ b/Common/CacheManager.h
@@ -147,13 +147,9 @@ public:
 	void updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, const wxString& timeStamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
 	void updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
 	void updateGateway(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol,bool addrLock, bool protoLock);
-	void updateGatewayG2(const wxString& gateway, const wxString& address, unsigned int g2Port);
+	void updateGatewayG2(const wxString& gateway, const in_addr& address, unsigned int g2Port);
 
 private:
-	void updateUser(const wxString& user, const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, const wxString& timeStamp, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
-	void updateRepeater(const wxString& repeater, const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
-	void updateGateway(const wxString& gateway, const wxString& address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol,bool addrLock, bool protoLock);
-
 	wxMutex        m_mutex;
 	CUserCache     m_userCache;
 	CGatewayCache  m_gatewayCache;

--- a/Common/CacheManager.h
+++ b/Common/CacheManager.h
@@ -77,11 +77,12 @@ private:
 
 class CRepeaterData {
 public:
-	CRepeaterData(const wxString& repeater, const wxString& gateway, in_addr address, DSTAR_PROTOCOL protocol) :
+	CRepeaterData(const wxString& repeater, const wxString& gateway, in_addr address, DSTAR_PROTOCOL protocol, unsigned int g2Port) :
 	m_repeater(repeater),
 	m_gateway(gateway),
 	m_address(address),
-	m_protocol(protocol)
+	m_protocol(protocol),
+	m_g2Port(g2Port)
 	{
 	}
 
@@ -105,19 +106,26 @@ public:
 		return m_protocol;
 	}
 
+	unsigned int getG2Port() const
+	{
+		return m_g2Port;
+	}
+
 private:
 	wxString       m_repeater;
 	wxString       m_gateway;
 	in_addr        m_address;
 	DSTAR_PROTOCOL m_protocol;
+	unsigned int m_g2Port;
 };
 
 class CGatewayData {
 public:
-	CGatewayData(const wxString& gateway, in_addr address, DSTAR_PROTOCOL protocol) :
+	CGatewayData(const wxString& gateway, in_addr address, DSTAR_PROTOCOL protocol, unsigned int g2Port) :
 	m_gateway(gateway),
 	m_address(address),
-	m_protocol(protocol)
+	m_protocol(protocol),
+	m_g2Port(g2Port)
 	{
 	}
 
@@ -136,10 +144,16 @@ public:
 		return m_protocol;
 	}
 
+    unsigned int getG2Port() const
+	{
+		return m_g2Port;
+	}
+
 private:
 	wxString       m_gateway;
 	in_addr        m_address;
 	DSTAR_PROTOCOL m_protocol;
+	unsigned int   m_g2Port;
 };
 
 class CCacheManager {

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="IRCDDBGatewayConfig.cpp" />
     <ClCompile Include="LogEvent.cpp" />
     <ClCompile Include="Logger.cpp" />
+    <ClCompile Include="NatTraversalHandler.cpp" />
     <ClCompile Include="PollData.cpp" />
     <ClCompile Include="RemoteHandler.cpp" />
     <ClCompile Include="RemoteLinkData.cpp" />
@@ -260,6 +261,7 @@
     <ClInclude Include="IRCDDBGatewayConfig.h" />
     <ClInclude Include="LogEvent.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="NatTraversalHandler.h" />
     <ClInclude Include="PollData.h" />
     <ClInclude Include="ReflectorCallback.h" />
     <ClInclude Include="RemoteHandler.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -209,6 +209,9 @@
     <ClCompile Include="XLXHostsFileDownloader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="NatTraversalHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AMBEData.h">
@@ -431,6 +434,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="XLXHostsFileDownloader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="NatTraversalHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Common/G2ProtocolHandler.cpp
+++ b/Common/G2ProtocolHandler.cpp
@@ -95,9 +95,6 @@ bool CG2ProtocolHandler::readPackets(in_addr& remoteAddress, unsigned int& remot
 	if (length <= 0)
 		return false;
 
-	if(length >= 1)
-		wxLogMessage(wxT("bla %i"), length);
-
 	m_length = length;
 
 	if (m_buffer[0] != 'D' || m_buffer[1] != 'S' || m_buffer[2] != 'V' || m_buffer[3] != 'T') {

--- a/Common/G2ProtocolHandler.cpp
+++ b/Common/G2ProtocolHandler.cpp
@@ -89,6 +89,8 @@ bool CG2ProtocolHandler::readPackets(in_addr& incomingAddress, unsigned int& inc
 {
 	m_type = GT_NONE;
 
+	incomingPort = 0;
+
 	// No more data?
 	int length = m_socket.read(m_buffer, BUFFER_LENGTH, incomingAddress, incomingPort);
 	if (length <= 0)

--- a/Common/G2ProtocolHandler.cpp
+++ b/Common/G2ProtocolHandler.cpp
@@ -147,7 +147,7 @@ CAMBEData* CG2ProtocolHandler::readAMBE(in_addr remoteAddress, unsigned int remo
 	return data;
 }
 
-void CG2ProtocolHandler::punchUDPHole(const wxString& address)
+void CG2ProtocolHandler::traverseNat(const wxString& address)
 {
 	unsigned char buffer[1];
 	::memset(buffer, 0, 1);

--- a/Common/G2ProtocolHandler.h
+++ b/Common/G2ProtocolHandler.h
@@ -52,7 +52,7 @@ public:
 	CHeaderData* readHeader(in_addr incomingAddress, unsigned int incomingPort);
 	CAMBEData*   readAMBE(in_addr incomingAddress, unsigned int incomingPort);
 
-	void punchUDPHole(const wxString& addr);
+	void traverseNat(const wxString& addr);
 
 	void close();
 

--- a/Common/G2ProtocolHandler.h
+++ b/Common/G2ProtocolHandler.h
@@ -48,9 +48,9 @@ public:
 	bool writeHeader(const CHeaderData& header);
 	bool writeAMBE(const CAMBEData& data);
 
-	G2_TYPE read();
-	CHeaderData* readHeader();
-	CAMBEData*   readAMBE();
+	G2_TYPE read(in_addr& incomingAddress, unsigned int& incomingPort);
+	CHeaderData* readHeader(in_addr incomingAddress, unsigned int incomingPort);
+	CAMBEData*   readAMBE(in_addr incomingAddress, unsigned int incomingPort);
 
 	void punchUDPHole(const wxString& addr);
 
@@ -61,10 +61,8 @@ private:
 	G2_TYPE          m_type;
 	unsigned char*   m_buffer;
 	unsigned int     m_length;
-	in_addr          m_address;
-	unsigned int     m_port;
 
-	bool readPackets();
+	bool readPackets(in_addr& incomingAddress, unsigned int& incomingPort);
 };
 
 #endif

--- a/Common/GatewayCache.cpp
+++ b/Common/GatewayCache.cpp
@@ -36,7 +36,7 @@ CGatewayRecord* CGatewayCache::find(const wxString& gateway)
 	return m_cache[gateway];
 }
 
-void CGatewayCache::update(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+void CGatewayCache::update(const wxString& gateway, const wxString& address,  unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
 	CGatewayRecord* rec = m_cache[gateway];
 
@@ -45,10 +45,10 @@ void CGatewayCache::update(const wxString& gateway, const wxString& address, DST
 
 	if (rec == NULL)
 		// A brand new record is needed
-		m_cache[gateway] = new CGatewayRecord(gateway, addr_in, protocol, addrLock, protoLock);
+		m_cache[gateway] = new CGatewayRecord(gateway, addr_in, g2Port, protocol, addrLock, protoLock);
 	else
 		// Update an existing record
-		rec->setData(addr_in, protocol, addrLock, protoLock);
+		rec->setData(addr_in, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
 }
 
 unsigned int CGatewayCache::getCount() const

--- a/Common/GatewayCache.cpp
+++ b/Common/GatewayCache.cpp
@@ -45,8 +45,10 @@ void CGatewayCache::update(const wxString& gateway, const wxString& address, DST
 
 	if(rec == NULL) {
 		rec = findByAddress(addr_in);//did this gateway punch to us and we do not have a gateway set for it ?
-		if(rec != NULL && rec->getGateway().empty())
-			rec->setGateway(gateway);
+		if(rec != NULL && rec->getGateway().empty() && rec->getProtocol() == protocol)
+		   rec->setGateway(gateway);
+		else
+			rec = NULL;
 	}
 
 	if (rec == NULL)

--- a/Common/GatewayCache.cpp
+++ b/Common/GatewayCache.cpp
@@ -43,6 +43,12 @@ void CGatewayCache::update(const wxString& gateway, const wxString& address, DST
 
 	CGatewayRecord* rec = m_cache[gateway];
 
+	if(rec == NULL) {
+		rec = findByAddress(addr_in);//did this gateway punch to us and we do not have a gateway set for it ?
+		if(rec->getGateway().empty())
+			rec->setGateway(gateway);
+	}
+
 	if (rec == NULL)
 		// A brand new record is needed
 		m_cache[gateway] = new CGatewayRecord(gateway, addr_in, G2_DV_PORT, protocol, addrLock, protoLock);
@@ -53,7 +59,7 @@ void CGatewayCache::update(const wxString& gateway, const wxString& address, DST
 
 void CGatewayCache::updateG2(const wxString& gateway, in_addr address,  unsigned int g2Port)
 {
-	//empty gateway means we are coming from udp hole punching, let see if we have an getway with matching address
+	//empty gateway means we are coming from udp hole punching, let see if we have an gateway with matching address
 	CGatewayRecord* rec = gateway.empty()? findByAddress(address) : m_cache[gateway];
 
 	if (rec == NULL) {

--- a/Common/GatewayCache.cpp
+++ b/Common/GatewayCache.cpp
@@ -45,7 +45,7 @@ void CGatewayCache::update(const wxString& gateway, const wxString& address, DST
 
 	if(rec == NULL) {
 		rec = findByAddress(addr_in);//did this gateway punch to us and we do not have a gateway set for it ?
-		if(rec->getGateway().empty())
+		if(rec != NULL && rec->getGateway().empty())
 			rec->setGateway(gateway);
 	}
 

--- a/Common/GatewayCache.cpp
+++ b/Common/GatewayCache.cpp
@@ -36,19 +36,48 @@ CGatewayRecord* CGatewayCache::find(const wxString& gateway)
 	return m_cache[gateway];
 }
 
-void CGatewayCache::update(const wxString& gateway, const wxString& address,  unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+void CGatewayCache::update(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 {
-	CGatewayRecord* rec = m_cache[gateway];
-
 	in_addr addr_in;
 	addr_in.s_addr = ::inet_addr(address.mb_str());
 
+	CGatewayRecord* rec = m_cache[gateway];
+
 	if (rec == NULL)
 		// A brand new record is needed
-		m_cache[gateway] = new CGatewayRecord(gateway, addr_in, g2Port, protocol, addrLock, protoLock);
+		m_cache[gateway] = new CGatewayRecord(gateway, addr_in, G2_DV_PORT, protocol, addrLock, protoLock);
 	else
 		// Update an existing record
-		rec->setData(addr_in, g2Port, ignoreG2Port, protocol, addrLock, protoLock);
+		rec->setData(addr_in, protocol, addrLock, protoLock);
+}
+
+void CGatewayCache::updateG2(const wxString& gateway, in_addr address,  unsigned int g2Port)
+{
+	//empty gateway means we are coming from udp hole punching, let see if we have an getway with matching address
+	CGatewayRecord* rec = gateway.empty()? findByAddress(address) : m_cache[gateway];
+
+	if (rec == NULL) {
+		// A brand new record is needed
+		m_cache[gateway] = new CGatewayRecord(gateway, address, g2Port, DP_UNKNOWN, false, false);
+	}
+	else {
+		// Update an existing record
+		if(rec->getGateway().empty())//if this is a record created from a punch call, set its gateway
+			rec->setGateway(gateway);
+
+		rec->setG2Data(address, g2Port);
+	}
+}
+
+CGatewayRecord* CGatewayCache::findByAddress(in_addr address)
+{
+	for (CGatewayCache_t::iterator it = m_cache.begin(); it != m_cache.end(); ++it) {
+		if(it-> second != NULL
+		   && it->second->getAddress().s_addr == address.s_addr)
+			return it->second;
+	}
+
+	return NULL;
 }
 
 unsigned int CGatewayCache::getCount() const

--- a/Common/GatewayCache.h
+++ b/Common/GatewayCache.h
@@ -69,7 +69,7 @@ public:
 		return m_protocol;
 	}
 
-	unsigned int g2Port() const
+	unsigned int getG2Port() const
 	{
 		return m_g2Port;
 	}

--- a/Common/GatewayCache.h
+++ b/Common/GatewayCache.h
@@ -81,6 +81,9 @@ public:
 private:
 	wxString       m_gateway;
 	in_addr        m_address;
+	
+	//the incoming G2 port, usually the default one unless the calling hotspot is behind a NAT, therefore keep track of it and use it to answer back instead of the default one
+	unsigned int   m_G2Port;
 	DSTAR_PROTOCOL m_protocol;
 	bool           m_addrLock;
 	bool           m_protoLock;

--- a/Common/GatewayCache.h
+++ b/Common/GatewayCache.h
@@ -35,9 +35,10 @@
 
 class CGatewayRecord {
 public:
-	CGatewayRecord(const wxString& gateway, in_addr address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock) :
+	CGatewayRecord(const wxString& gateway, in_addr address, unsigned int g2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock) :
 	m_gateway(gateway),
 	m_address(address),
+	m_g2Port(g2Port),
 	m_protocol(DP_UNKNOWN),
 	m_addrLock(addrLock),
 	m_protoLock(false)
@@ -63,8 +64,16 @@ public:
 		return m_protocol;
 	}
 
-	void setData(in_addr address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+	unsigned int g2Port() const
 	{
+		return m_g2Port;
+	}
+
+	void setData(in_addr address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+	{
+		if(!ignoreG2Port)
+			m_g2Port = g2Port;
+
 		if (!m_addrLock) {
 			m_address  = address;
 			m_addrLock = addrLock;
@@ -80,10 +89,9 @@ public:
 
 private:
 	wxString       m_gateway;
-	in_addr        m_address;
-	
+	in_addr        m_address;	
 	//the incoming G2 port, usually the default one unless the calling hotspot is behind a NAT, therefore keep track of it and use it to answer back instead of the default one
-	unsigned int   m_G2Port;
+	unsigned int   m_g2Port;
 	DSTAR_PROTOCOL m_protocol;
 	bool           m_addrLock;
 	bool           m_protoLock;
@@ -98,7 +106,7 @@ public:
 
 	CGatewayRecord* find(const wxString& gateway);
 
-	void update(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void update(const wxString& gateway, const wxString& address, unsigned int g2port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
 
 	unsigned int getCount() const;
 

--- a/Common/GatewayCache.h
+++ b/Common/GatewayCache.h
@@ -54,6 +54,11 @@ public:
 		return m_gateway;
 	}
 
+	void setGateway(const wxString& gateway)
+	{
+		m_gateway = gateway;
+	}
+
 	in_addr getAddress() const
 	{
 		return m_address;
@@ -69,11 +74,8 @@ public:
 		return m_g2Port;
 	}
 
-	void setData(in_addr address, unsigned int g2Port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
+	void setData(in_addr address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock)
 	{
-		if(!ignoreG2Port)
-			m_g2Port = g2Port;
-
 		if (!m_addrLock) {
 			m_address  = address;
 			m_addrLock = addrLock;
@@ -87,10 +89,19 @@ public:
 		}
 	}
 
+	void setG2Data(in_addr address, unsigned int g2Port)
+	{
+		if (!m_addrLock) {
+			m_address  = address;
+		}
+
+		m_g2Port = g2Port;
+	}
+
 private:
 	wxString       m_gateway;
 	in_addr        m_address;	
-	//the incoming G2 port, usually the default one unless the calling hotspot is behind a NAT, therefore keep track of it and use it to answer back instead of the default one
+	//the incoming G2 port, keep track of it and use it to answer back instead of the default one. This helps us defeat NAT with no port forwarding to G2_DVPORT
 	unsigned int   m_g2Port;
 	DSTAR_PROTOCOL m_protocol;
 	bool           m_addrLock;
@@ -106,11 +117,14 @@ public:
 
 	CGatewayRecord* find(const wxString& gateway);
 
-	void update(const wxString& gateway, const wxString& address, unsigned int g2port, bool ignoreG2Port, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void update(const wxString& gateway, const wxString& address, DSTAR_PROTOCOL protocol, bool addrLock, bool protoLock);
+	void updateG2(const wxString& gateway, in_addr address, unsigned int g2Port);
 
 	unsigned int getCount() const;
 
 private:
+	CGatewayRecord* findByAddress(in_addr address);
+
 	CGatewayCache_t m_cache;
 };
 

--- a/Common/Makefile
+++ b/Common/Makefile
@@ -4,7 +4,7 @@ OBJECTS = AMBEData.o AnnouncementUnit.o APRSCollector.o APRSWriter.o APRSWriterT
 	  DPlusAuthenticator.o DPlusHandler.o DPlusProtocolHandler.o DPlusProtocolHandlerPool.o DRATSServer.o DTMF.o \
 	  DummyRepeaterProtocolHandler.o DVTOOLFileReader.o EchoUnit.o G2Handler.o G2ProtocolHandler.o GatewayCache.o \
 	  HBRepeaterProtocolHandler.o HeaderData.o HeaderLogger.o HeardData.o HostFile.o IcomRepeaterProtocolHandler.o IRCDDBGatewayConfig.o \
-	  LogEvent.o Logger.o PollData.o RemoteHandler.o RemoteLinkData.o RemoteProtocolHandler.o RemoteRepeaterData.o RemoteStarNetGroup.o \
+	  LogEvent.o Logger.o NatTraversalHandler.o PollData.o RemoteHandler.o RemoteLinkData.o RemoteProtocolHandler.o RemoteRepeaterData.o RemoteStarNetGroup.o \
 	  RemoteStarNetUser.o RepeaterCache.o RepeaterHandler.o SHA256.o SlowDataEncoder.o StarNetHandler.o StatusData.o \
 	  TCPReaderWriterClient.o TCPReaderWriterServer.o TextCollector.o TextData.o Timer.o UDPReaderWriter.o UserCache.o Utils.o \
 	  VersionUnit.o XLXHostsFileDownloader.o

--- a/Common/NatTraversalHandler.cpp
+++ b/Common/NatTraversalHandler.cpp
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (C) 2010,2011,2012,2013,2014,2015,2016,2017,2018 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "NatTraversalHandler.h"
+
+const unsigned int CACHE_SIZE = 500U;
+
+CNatTraversalHandler::CNatTraversalHandler() :
+m_g2cache(CACHE_SIZE),
+m_g2Handler(NULL)
+{
+
+}
+
+CNatTraversalHandler::~CNatTraversalHandler()
+{
+    for (CNatTraversalCache_t::iterator it = m_g2cache.begin(); it != m_g2cache.end(); ++it)
+		delete it->second;
+}
+
+void CNatTraversalHandler::setG2Handler(CG2ProtocolHandler * handler)
+{
+    m_g2Handler = handler;
+}
+
+void CNatTraversalHandler::traverseNatG2(const wxString& address)
+{
+    if(m_g2Handler != NULL){
+        CNatTraversalRecord* record = m_g2cache[address];
+        
+        if(record == NULL) {
+            record = new CNatTraversalRecord(address);
+            m_g2cache[address] = record;
+        }
+
+        std::time_t currentTime = std::time(NULL);
+        if(currentTime - record->getTimestamp() > G2_TRAVERSAL_TIMEOUT) {
+            record->setTimestamp(currentTime);
+            m_g2Handler->traverseNat(address);
+        }
+    }
+}

--- a/Common/NatTraversalHandler.h
+++ b/Common/NatTraversalHandler.h
@@ -19,7 +19,7 @@
 #ifndef NatTraversalHandler_H
 #define NatTraversalHandler_H
 
-#define G2_TRAVERSAL_TIMEOUT 120 //seconds
+#define G2_TRAVERSAL_TIMEOUT 60 //seconds
 
 #include "G2ProtocolHandler.h"
 

--- a/Common/NatTraversalHandler.h
+++ b/Common/NatTraversalHandler.h
@@ -19,7 +19,7 @@
 #ifndef NatTraversalHandler_H
 #define NatTraversalHandler_H
 
-#define G2_TRAVERSAL_TIMEOUT 60 //seconds
+#define G2_TRAVERSAL_TIMEOUT 29 //seconds
 
 #include "G2ProtocolHandler.h"
 

--- a/Common/NatTraversalHandler.h
+++ b/Common/NatTraversalHandler.h
@@ -1,0 +1,77 @@
+/*
+ *   Copyright (C) 2010,2011,2012,2013,2014,2015,2016,2017,2018 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef NatTraversalHandler_H
+#define NatTraversalHandler_H
+
+#define G2_TRAVERSAL_TIMEOUT 120 //seconds
+
+#include "G2ProtocolHandler.h"
+
+#include <wx/wx.h>
+#include <ctime>
+
+enum NAT_TRAVERSAL_TYPE {
+    NTT_G2,
+    //NTT_DEXTRA
+    //NTT_DCS
+    //NTT_DPLUS
+};
+
+class CNatTraversalRecord {
+public:
+    CNatTraversalRecord(const wxString& address) :
+    m_address(address),
+    m_timestamp(0)
+    {
+    }
+
+    std::time_t getTimestamp() const
+    {
+        return m_timestamp;
+    }
+
+    void setTimestamp(std::time_t timestamp)
+    {
+        m_timestamp = timestamp;
+    }
+
+private:
+    wxString m_address;
+    std::time_t m_timestamp;
+};
+
+WX_DECLARE_STRING_HASH_MAP(CNatTraversalRecord*, CNatTraversalCache_t);
+
+/*
+* This keeps track of when we UDP punched to one destination so to avoid unnecessary traffic on each ircddb reporting
+*/
+class CNatTraversalHandler {
+public:
+    CNatTraversalHandler();
+    ~CNatTraversalHandler();
+
+    void setG2Handler(CG2ProtocolHandler* handler);
+    void traverseNatG2(const wxString& address);
+
+private:
+    CNatTraversalCache_t m_g2cache;    
+    CG2ProtocolHandler* m_g2Handler;
+};
+
+#endif

--- a/Common/RepeaterHandler.cpp
+++ b/Common/RepeaterHandler.cpp
@@ -109,6 +109,7 @@ m_g2Repeater(),
 m_g2Gateway(),
 m_g2Header(NULL),
 m_g2Address(),
+m_g2Port(G2_DV_PORT),
 m_linkStatus(LS_NONE),
 m_linkRepeater(),
 m_linkGateway(),
@@ -632,6 +633,7 @@ void CRepeaterHandler::processRepeater(CHeaderData& header)
 	m_g2User.Clear();
 	m_g2Repeater.Clear();
 	m_g2Gateway.Clear();
+	m_g2Port = G2_DV_PORT;
 
 	// Check if this user is restricted
 	m_restricted = false;
@@ -829,7 +831,7 @@ void CRepeaterHandler::processRepeater(CAMBEData& data)
 			break;
 
 		case G2_OK:
-			data.setDestination(m_g2Address, G2_DV_PORT);
+			data.setDestination(m_g2Address, m_g2Port);
 			m_g2Handler->writeAMBE(data);
 
 			if (data.isEnd()) {
@@ -1213,7 +1215,7 @@ void CRepeaterHandler::resolveUserInt(const wxString& user, const wxString& repe
 			m_g2Repeater = repeater;
 			m_g2Gateway  = gateway;
 
-			m_g2Header->setDestination(m_g2Address, G2_DV_PORT);
+			m_g2Header->setDestination(m_g2Address, m_g2Port);
 			m_g2Header->setRepeaters(m_g2Gateway, m_g2Repeater);
 			m_g2Handler->writeHeader(*m_g2Header);
 
@@ -1226,6 +1228,7 @@ void CRepeaterHandler::resolveUserInt(const wxString& user, const wxString& repe
 			m_g2User.Clear();
 			m_g2Repeater.Clear();
 			m_g2Gateway.Clear();
+			m_g2Port = G2_DV_PORT;
 
 			delete m_g2Header;
 			m_g2Header = NULL;
@@ -1245,7 +1248,10 @@ void CRepeaterHandler::resolveRepeaterInt(const wxString& repeater, const wxStri
 			m_g2Repeater = repeater;
 			m_g2Gateway  = gateway;
 
-			m_g2Header->setDestination(m_g2Address, G2_DV_PORT);
+			CRepeaterData* rpt = m_cache->findRepeater(repeater);
+			m_g2Port = rpt != NULL ? rpt->getG2Port() : G2_DV_PORT;
+
+			m_g2Header->setDestination(m_g2Address, m_g2Port);
 			m_g2Header->setRepeaters(m_g2Gateway, m_g2Repeater);
 			m_g2Handler->writeHeader(*m_g2Header);
 
@@ -1258,6 +1264,7 @@ void CRepeaterHandler::resolveRepeaterInt(const wxString& repeater, const wxStri
 			m_g2User.Clear();
 			m_g2Repeater.Clear();
 			m_g2Gateway.Clear();
+			m_g2Port = G2_DV_PORT;
 
 			delete m_g2Header;
 			m_g2Header = NULL;
@@ -1459,6 +1466,7 @@ void CRepeaterHandler::clockInt(unsigned int ms)
 			m_g2User.Clear();
 			m_g2Repeater.Clear();
 			m_g2Gateway.Clear();
+			m_g2Port = G2_DV_PORT;
 
 			delete m_g2Header;
 			m_g2Header = NULL;
@@ -1983,7 +1991,8 @@ void CRepeaterHandler::g2CommandHandler(const wxString& callsign, const wxString
 			m_g2Status = G2_OK;
 			m_g2Address = data->getAddress();
 			m_g2Gateway = data->getGateway();
-			header.setDestination(m_g2Address, G2_DV_PORT);
+			m_g2Port = data->getG2Port();
+			header.setDestination(m_g2Address, m_g2Port);
 			header.setRepeaters(m_g2Gateway, m_g2Repeater);
 			m_g2Handler->writeHeader(header);
 			delete data;
@@ -2025,7 +2034,9 @@ void CRepeaterHandler::g2CommandHandler(const wxString& callsign, const wxString
 			m_g2Address  = data->getAddress();
 			m_g2Repeater = data->getRepeater();
 			m_g2Gateway  = data->getGateway();
-			header.setDestination(m_g2Address, data->getG2Port());
+			m_g2Port     = data->getG2Port();
+			wxLogMessage(wxT("%s is trying to G2 route to gateway %s on port %d"), user.c_str(), m_g2Gateway.c_str(), m_g2Port);
+			header.setDestination(m_g2Address, m_g2Port);
 			header.setRepeaters(m_g2Gateway, m_g2Repeater);
 			m_g2Handler->writeHeader(header);
 

--- a/Common/RepeaterHandler.cpp
+++ b/Common/RepeaterHandler.cpp
@@ -2025,7 +2025,7 @@ void CRepeaterHandler::g2CommandHandler(const wxString& callsign, const wxString
 			m_g2Address  = data->getAddress();
 			m_g2Repeater = data->getRepeater();
 			m_g2Gateway  = data->getGateway();
-			header.setDestination(m_g2Address, G2_DV_PORT);
+			header.setDestination(m_g2Address, data->getG2Port());
 			header.setRepeaters(m_g2Gateway, m_g2Repeater);
 			m_g2Handler->writeHeader(header);
 

--- a/Common/RepeaterHandler.h
+++ b/Common/RepeaterHandler.h
@@ -232,6 +232,7 @@ private:
 	wxString                  m_g2Gateway;
 	CHeaderData*              m_g2Header;
 	in_addr                   m_g2Address;
+    unsigned int              m_g2Port;
 
 	// Link info
 	LINK_STATUS               m_linkStatus;

--- a/StarNetServer/StarNetServerThread.cpp
+++ b/StarNetServer/StarNetServerThread.cpp
@@ -505,15 +505,15 @@ void CStarNetServerThread::processDCS()
 
 void CStarNetServerThread::processG2()
 {
+	in_addr incomingAddress;
+	unsigned int incomingPort;
+
 	for (;;) {
-		G2_TYPE type = m_g2Handler->read();
+		G2_TYPE type = m_g2Handler->read(incomingAddress, incomingPort);
 
 		switch (type) {
-			case GT_NONE:
-				return;
-
 			case GT_HEADER: {
-					CHeaderData* header = m_g2Handler->readHeader();
+					CHeaderData* header = m_g2Handler->readHeader(incomingAddress, incomingPort);
 					if (header != NULL) {
 						// wxLogMessage(wxT("G2 header - My: %s/%s  Your: %s  Rpt1: %s  Rpt2: %s  Flags: %02X %02X %02X"), header->getMyCall1().c_str(), header->getMyCall2().c_str(), header->getYourCall().c_str(), header->getRptCall1().c_str(), header->getRptCall2().c_str(), header->getFlag1(), header->getFlag2(), header->getFlag3());
 						CG2Handler::process(*header);
@@ -523,13 +523,17 @@ void CStarNetServerThread::processG2()
 				break;
 
 			case GT_AMBE: {
-					CAMBEData* data = m_g2Handler->readAMBE();
+					CAMBEData* data = m_g2Handler->readAMBE(incomingAddress, incomingPort);
 					if (data != NULL) {
 						CG2Handler::process(*data);
 						delete data;
 					}
 				}
 				break;
+
+			default:
+				//Probably someone punching a UDP hole to us
+				return;
 		}
 	}
 }

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1056,8 +1056,10 @@ void CIRCDDBGatewayThread::processG2()
 
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
-				if(incomingAddress.s_addr != INADDR_NONE && incomingPort > 0  && incomingPort < 65536)
+				if(incomingAddress.s_addr != INADDR_NONE && incomingPort > 0  && incomingPort < 65536) {
+					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(incomingAddress), incomingPort));
 					m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
+				}
 					
 				return;
 		}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -72,6 +72,7 @@ m_dextraPool(NULL),
 m_dplusPool(NULL),
 m_dcsPool(NULL),
 m_g2Handler(NULL),
+m_natTraversal(NULL),
 m_aprsWriter(NULL),
 m_irc(NULL),
 m_cache(),
@@ -215,6 +216,11 @@ void CIRCDDBGatewayThread::run()
 		wxLogError(wxT("Could not open the G2 protocol handler"));
 		delete m_g2Handler;
 		m_g2Handler = NULL;
+	}
+
+	if(m_g2Handler != NULL) {
+		m_natTraversal = new CNatTraversalHandler();
+		m_natTraversal->setG2Handler(m_g2Handler);
 	}
 
 	// Wait here until we have the essentials to run
@@ -719,7 +725,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("USER: %s %s %s %s"), user.c_str(), repeater.c_str(), gateway.c_str(), address.c_str());
 						m_cache.updateUser(user, repeater, gateway, address, timestamp, DP_DEXTRA, false, false);
-						m_g2Handler->punchUDPHole(address);
+						m_natTraversal->traverseNatG2(address);
 					} else {
 						wxLogMessage(wxT("USER: %s NOT FOUND"), user.c_str());
 					}
@@ -735,7 +741,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("REPEATER: %s %s %s"), repeater.c_str(), gateway.c_str(), address.c_str());
 						m_cache.updateRepeater(repeater, gateway, address, DP_DEXTRA, false, false);
-						m_g2Handler->punchUDPHole(address);
+						m_natTraversal->traverseNatG2(address);
 					} else {
 						wxLogMessage(wxT("REPEATER: %s NOT FOUND"), repeater.c_str());
 					}
@@ -756,7 +762,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("GATEWAY: %s %s"), gateway.c_str(), address.c_str());
 						m_cache.updateGateway(gateway, address, DP_DEXTRA, false, false);
-						m_g2Handler->punchUDPHole(address);
+						m_natTraversal->traverseNatG2(address);
 					} else {
 						wxLogMessage(wxT("GATEWAY: %s NOT FOUND"), gateway.c_str());
 					}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1060,11 +1060,8 @@ void CIRCDDBGatewayThread::processG2()
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
 				if(remoteAddress.s_addr != INADDR_NONE && remotePort > 0  && remotePort < 65536) {
-			
 					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(remoteAddress), remotePort);
-			
 					m_cache.updateGatewayG2(wxT(""), remoteAddress, remotePort);
-			
 				}
 					
 				return;

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1025,12 +1025,15 @@ void CIRCDDBGatewayThread::processDCS()
 
 void CIRCDDBGatewayThread::processG2()
 {
+	in_addr incomingAddress;
+	unsigned int incomingPort;
+
 	for (;;) {
-		G2_TYPE type = m_g2Handler->read();
+		G2_TYPE type = m_g2Handler->read(incomingAddress, incomingPort);
 
 		switch (type) {
 			case GT_HEADER: {
-					CHeaderData* header = m_g2Handler->readHeader();
+					CHeaderData* header = m_g2Handler->readHeader(incomingAddress, incomingPort);
 					if (header != NULL) {
 						// wxLogMessage(wxT("G2 header - My: %s/%s  Your: %s  Rpt1: %s  Rpt2: %s  Flags: %02X %02X %02X"), header->getMyCall1().c_str(), header->getMyCall2().c_str(), header->getYourCall().c_str(), header->getRptCall1().c_str(), header->getRptCall2().c_str(), header->getFlag1(), header->getFlag2(), header->getFlag3());
 						CG2Handler::process(*header);
@@ -1040,7 +1043,7 @@ void CIRCDDBGatewayThread::processG2()
 				break;
 
 			case GT_AMBE: {
-					CAMBEData* data = m_g2Handler->readAMBE();
+					CAMBEData* data = m_g2Handler->readAMBE(incomingAddress, incomingPort);
 					if (data != NULL) {
 						CG2Handler::process(*data);
 						delete data;
@@ -1049,6 +1052,7 @@ void CIRCDDBGatewayThread::processG2()
 				break;
 
 			default:
+				//Probably someone punching a UDP hole to us
 				return;
 		}
 	}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1037,6 +1037,7 @@ void CIRCDDBGatewayThread::processG2()
 					if (header != NULL) {
 						// wxLogMessage(wxT("G2 header - My: %s/%s  Your: %s  Rpt1: %s  Rpt2: %s  Flags: %02X %02X %02X"), header->getMyCall1().c_str(), header->getMyCall2().c_str(), header->getYourCall().c_str(), header->getRptCall1().c_str(), header->getRptCall2().c_str(), header->getFlag1(), header->getFlag2(), header->getFlag3());
 						CG2Handler::process(*header);
+						m_cache.updateGatewayG2(header-> getRptCall1(), wxT("127.0.0.1"), incomingPort);
 						delete header;
 					}
 				}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1056,8 +1056,9 @@ void CIRCDDBGatewayThread::processG2()
 
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
-				if(incomingPort > 0 && incomingPort < 65536)
+				if(incomingAddress.s_addr != INADDR_NONE && incomingPort > 0  && incomingPort < 65536)
 					m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
+					
 				return;
 		}
 	}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1054,7 +1054,8 @@ void CIRCDDBGatewayThread::processG2()
 
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
-				m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
+				if(incomingPort > 0 && incomingPort < 65536)
+					m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
 				return;
 		}
 	}

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1027,26 +1027,29 @@ void CIRCDDBGatewayThread::processDCS()
 
 void CIRCDDBGatewayThread::processG2()
 {
-	in_addr incomingAddress;
-	unsigned int incomingPort;
+	in_addr remoteAddress;
+	unsigned int remotePort;
 
 	for (;;) {
-		G2_TYPE type = m_g2Handler->read(incomingAddress, incomingPort);
+		G2_TYPE type = m_g2Handler->read(remoteAddress, remotePort);
 
 		switch (type) {
 			case GT_HEADER: {
-					CHeaderData* header = m_g2Handler->readHeader(incomingAddress, incomingPort);
+					CHeaderData* header = m_g2Handler->readHeader(remoteAddress, remotePort);
+			
 					if (header != NULL) {
 						// wxLogMessage(wxT("G2 header - My: %s/%s  Your: %s  Rpt1: %s  Rpt2: %s  Flags: %02X %02X %02X"), header->getMyCall1().c_str(), header->getMyCall2().c_str(), header->getYourCall().c_str(), header->getRptCall1().c_str(), header->getRptCall2().c_str(), header->getFlag1(), header->getFlag2(), header->getFlag3());
 						CG2Handler::process(*header);
-						m_cache.updateGatewayG2(header-> getRptCall1(), incomingAddress, incomingPort);
+						m_cache.updateGatewayG2(header-> getRptCall1(), remoteAddress, remotePort);
+				
 						delete header;
 					}
 				}
 				break;
 
 			case GT_AMBE: {
-					CAMBEData* data = m_g2Handler->readAMBE(incomingAddress, incomingPort);
+					CAMBEData* data = m_g2Handler->readAMBE(remoteAddress, remotePort);
+			
 					if (data != NULL) {
 						CG2Handler::process(*data);
 						delete data;
@@ -1056,9 +1059,12 @@ void CIRCDDBGatewayThread::processG2()
 
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
-				if(incomingAddress.s_addr != INADDR_NONE && incomingPort > 0  && incomingPort < 65536) {
-					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(incomingAddress), incomingPort);
-					m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
+				if(remoteAddress.s_addr != INADDR_NONE && remotePort > 0  && remotePort < 65536) {
+			
+					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(remoteAddress), remotePort);
+			
+					m_cache.updateGatewayG2(wxT(""), remoteAddress, remotePort);
+			
 				}
 					
 				return;

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -732,7 +732,6 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!res)
 						break;
 
-					CRepeaterHandler::resolveRepeater(repeater, gateway, address, DP_DEXTRA);
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("REPEATER: %s %s %s"), repeater.c_str(), gateway.c_str(), address.c_str());
 						m_cache.updateRepeater(repeater, gateway, address, DP_DEXTRA, false, false);
@@ -740,6 +739,9 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					} else {
 						wxLogMessage(wxT("REPEATER: %s NOT FOUND"), repeater.c_str());
 					}
+
+					//resolve after updating cache so CRepeaterHandler gets latest g2 port from cache
+					CRepeaterHandler::resolveRepeater(repeater, gateway, address, DP_DEXTRA);
 				}
 				break;
 

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1066,7 +1066,7 @@ void CIRCDDBGatewayThread::processG2()
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
 				if(remoteAddress.s_addr != INADDR_NONE && remotePort > 0  && remotePort < 65536) {
-					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(remoteAddress), remotePort);
+					wxLogMessage(wxT("Incoming G2 UDP traversal from %s:%i"), ::inet_ntoa(remoteAddress), remotePort);
 					m_cache.updateGatewayG2(wxT(""), remoteAddress, remotePort);
 				}
 					

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1057,7 +1057,7 @@ void CIRCDDBGatewayThread::processG2()
 			default:
 				//Probably someone punching a UDP hole to us, keep track of that
 				if(incomingAddress.s_addr != INADDR_NONE && incomingPort > 0  && incomingPort < 65536) {
-					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(incomingAddress), incomingPort));
+					wxLogMessage(wxT("Incoming G2 UDP punch from %s:%i"), ::inet_ntoa(incomingAddress), incomingPort);
 					m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
 				}
 					

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1037,7 +1037,7 @@ void CIRCDDBGatewayThread::processG2()
 					if (header != NULL) {
 						// wxLogMessage(wxT("G2 header - My: %s/%s  Your: %s  Rpt1: %s  Rpt2: %s  Flags: %02X %02X %02X"), header->getMyCall1().c_str(), header->getMyCall2().c_str(), header->getYourCall().c_str(), header->getRptCall1().c_str(), header->getRptCall2().c_str(), header->getFlag1(), header->getFlag2(), header->getFlag3());
 						CG2Handler::process(*header);
-						m_cache.updateGatewayG2(header-> getRptCall1(), wxT("127.0.0.1"), incomingPort);
+						m_cache.updateGatewayG2(header-> getRptCall1(), incomingAddress, incomingPort);
 						delete header;
 					}
 				}
@@ -1053,7 +1053,8 @@ void CIRCDDBGatewayThread::processG2()
 				break;
 
 			default:
-				//Probably someone punching a UDP hole to us
+				//Probably someone punching a UDP hole to us, keep track of that
+				m_cache.updateGatewayG2(wxT(""), incomingAddress, incomingPort);
 				return;
 		}
 	}

--- a/ircDDBGateway/IRCDDBGatewayThread.h
+++ b/ircDDBGateway/IRCDDBGatewayThread.h
@@ -28,6 +28,7 @@
 #include "IRCDDBGatewayStatusData.h"
 #include "DCSProtocolHandlerPool.h"
 #include "G2ProtocolHandler.h"
+#include "NatTraversalHandler.h"
 #include "RemoteHandler.h"
 #include "CacheManager.h"
 #include "CallsignList.h"
@@ -92,6 +93,7 @@ private:
 	CDPlusProtocolHandlerPool*     m_dplusPool;
 	CDCSProtocolHandlerPool*       m_dcsPool;
 	CG2ProtocolHandler*       m_g2Handler;
+	CNatTraversalHandler*     m_natTraversal;
 	CAPRSWriter*              m_aprsWriter;
 	CIRCDDB*                  m_irc;
 	CCacheManager             m_cache;


### PR DESCRIPTION
Hi Jonathan,

Here is a second iteration of the G2 Nat Traversal.
- When a remote station punches to us, Keep track of the remote port and answer back on that port. This allows to defeat some more types of NATs. E.g. Previous version did not work behind Vodafone.de
- G2 ports are kept in cache
- Do not punch if we already punched within the last 29 seconds. I found out in my tests that some mobile operators are using a 30 seconds timeout

73
Geoffrey F4FXL / KC3FRA