### PR TITLE
Fix missing or empty CCS_Hosts.txt preventing to save the configuration

### DIFF
--- a/GUICommon/DCSSet.cpp
+++ b/GUICommon/DCSSet.cpp
@@ -21,6 +21,7 @@
 #include "Defs.h"
 
 #include <wx/filename.h>
+#include <wx/msw/msgdlg.h>
 
 const unsigned int CONTROL_WIDTH = 130U;
 
@@ -109,12 +110,14 @@ bool CDCSSet::Validate()
 	if (n == wxNOT_FOUND)
 		return false;
 
-	n = m_ccsEnabled->GetCurrentSelection();
-	if (n == wxNOT_FOUND)
-		return false;
+	bool ccsEnabled = m_ccsEnabled->GetCurrentSelection() == 1;
+	bool ccsHostSelected = m_ccsHosts->GetCurrentSelection() != wxNOT_FOUND;
 
-	if (m_ccsHosts->GetCurrentSelection() == wxNOT_FOUND)
+	if (ccsEnabled && !ccsHostSelected)	{
+		wxMessageDialog dialog(this, _("CCS is enabled and no CCS host has been selected. Either disable CCS or select a CCS host."), m_title + _(" Error"), wxICON_ERROR);
+		dialog.ShowModal();
 		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Hi Jonathan,

When trying to save configuration without or empty CCS_Hosts.txt the configuration was not saved and no error message was shown. This addresses this issue.

- Add error message so as to not leave user in the dark.
- Allow saving configuration when CCS_hosts.txt is empty/missing and CCS is disabled

73
Geoffrey F4FXL / KC3FRA