### PR TITLE
Update ircddbgateway-emptyconfig

### DIFF
--- a/ircDDBGateway/ircddbgateway-emptyconfig
+++ b/ircDDBGateway/ircddbgateway-emptyconfig
@@ -119,7 +119,7 @@ dcsEnabled=1
 ccsEnabled=1
 ccsHost=CCS704  
 xlxEnabled=1
-xlxHostsFileUrl=xlxHostsFileUrl=http://xlxapi.rlx.lu/api.php?do=GetXLXDMRMaster
+xlxHostsFileUrl=http://xlxapi.rlx.lu/api.php?do=GetXLXDMRMaster
 starNetBand1=A
 starNetCallsign1=        
 starNetLogoff1=        

--- a/ircDDBGateway/ircddbgateway-emptyconfig
+++ b/ircDDBGateway/ircddbgateway-emptyconfig
@@ -119,7 +119,7 @@ dcsEnabled=1
 ccsEnabled=1
 ccsHost=CCS704  
 xlxEnabled=1
-xlxHostsFileUrl=http://xlxapi.rlx.lu/api.php?do=GetReflectorHostname
+xlxHostsFileUrl=xlxHostsFileUrl=http://xlxapi.rlx.lu/api.php?do=GetXLXDMRMaster
 starNetBand1=A
 starNetCallsign1=        
 starNetLogoff1=        


### PR DESCRIPTION
Update default config xlxHostsFileUrl to pull XLX host list of current registered XLX reflectors only.  No protocols listed, just XLX reflector addresses.  Resolves issues raised in #39 and #46 .  I have been running with this config for a month now and it works well.