### PR TITLE
Adds console logging option to ircddbgatewayd

### DIFF
--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="ConnectData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ConsoleLogger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="DCSHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -257,6 +260,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ConnectData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ConsoleLogger.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="DCSHandler.h">

--- a/Common/ConsoleLogger.cpp
+++ b/Common/ConsoleLogger.cpp
@@ -1,0 +1,48 @@
+/*
+ *   Copyright (C) 2002,2003,2009,2011,2012,2019 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2020 by Adam Kolakowski SQ7LRX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "ConsoleLogger.h"
+
+const char CConsoleLogger::S_LEVELS[] = "FEWMMIDTPU";
+
+CConsoleLogger::CConsoleLogger() :
+wxLog(),
+m_stdout(new wxMessageOutputStderr(stdout)),
+m_stderr(new wxMessageOutputStderr(stderr))
+{
+}
+
+CConsoleLogger::~CConsoleLogger()
+{
+}
+
+void CConsoleLogger::DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info)
+{
+	if (level > 9)
+		level = 9;
+
+	if (level <= wxLOG_Error) {
+		m_stderr->Printf(wxT("%c: %s\n"), CConsoleLogger::S_LEVELS[level], msg.c_str());
+	} else {
+		m_stdout->Printf(wxT("%c: %s\n"), CConsoleLogger::S_LEVELS[level], msg.c_str());
+	}
+
+	if (level == wxLOG_FatalError)
+		::abort();
+}

--- a/Common/ConsoleLogger.h
+++ b/Common/ConsoleLogger.h
@@ -1,5 +1,6 @@
 /*
- *   Copyright (C) 2010-2013,2018 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2002,2003,2009,2011,2012,2019 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2020 by Adam Kolakowski SQ7LRX
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,39 +17,25 @@
  *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef	IRCDDBGatewayAppD_H
-#define	IRCDDBGatewayAppD_H
-
-#include "IRCDDBGatewayThread.h"
+#ifndef	ConsoleLogger_H
+#define	ConsoleLogger_H
 
 #include <wx/wx.h>
-#include <wx/config.h>
-#include <wx/snglinst.h>
 
-class CIRCDDBGatewayAppD {
 
+class CConsoleLogger : public wxLog {
 public:
-	CIRCDDBGatewayAppD(bool nolog, bool debug, bool foreground, const wxString& logDir, const wxString& confDir, const wxString& name);
-	~CIRCDDBGatewayAppD();
+	CConsoleLogger();
+	virtual ~CConsoleLogger();
 
-	bool init();
-
-	void run();
-
-	void kill();
+	virtual void DoLogRecord(wxLogLevel level, const wxString& msg, const wxLogRecordInfo& info);
 
 private:
-	wxString                 m_name;
-	bool                     m_nolog;
-	bool                     m_debug;
-	bool                     m_foreground;
-	wxString                 m_logDir;
-	wxString                 m_confDir;
-	CIRCDDBGatewayThread*    m_thread;
-	wxSingleInstanceChecker* m_checker;
+	const static char S_LEVELS[];
 
-	bool createThread();
-	void initLogging(wxLog *logger);
+	wxMessageOutput *m_stdout;
+	wxMessageOutput *m_stderr;
 };
 
 #endif
+

--- a/Common/Makefile
+++ b/Common/Makefile
@@ -1,5 +1,5 @@
 OBJECTS = AMBEData.o AnnouncementUnit.o APRSCollector.o APRSWriter.o APRSWriterThread.o AudioUnit.o CacheManager.o CallsignList.o \
-	  CallsignServer.o CCITTChecksum.o CCSData.o CCSHandler.o CCSProtocolHandler.o ConnectData.o DCSHandler.o DCSProtocolHandler.o \
+	  CallsignServer.o CCITTChecksum.o CCSData.o CCSHandler.o CCSProtocolHandler.o ConnectData.o ConsoleLogger.o DCSHandler.o DCSProtocolHandler.o \
 	  DCSProtocolHandlerPool.o DDData.o DDHandler.o DExtraHandler.o DExtraProtocolHandler.o DExtraProtocolHandlerPool.o \
 	  DPlusAuthenticator.o DPlusHandler.o DPlusProtocolHandler.o DPlusProtocolHandlerPool.o DRATSServer.o DTMF.o \
 	  DummyRepeaterProtocolHandler.o DVTOOLFileReader.o EchoUnit.o G2Handler.o G2ProtocolHandler.o GatewayCache.o \


### PR DESCRIPTION
When invoked with the `-foreground` parameter, ircddbgatewayd
will print all logs to the console (`stdout`/`stderr`) instead of log files.

This allows ircddbgatewayd to be run in a container or as a systemd
standard service where applications are expected to provide logs
on standard output / standard error.