### PR TITLE
Adds BUILD make variable for debug/release builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,6 @@
-ircDDB Gateway - 20180627
-=========================
+# Building ircDDBGateway
 
-Windows
--------
+## Windows
 
 To use the ircDDB Gateway software you will first need to build the latest
 version of wxWidgets (http://www.wxwidgets.org), the version I used was 3.0.4.
@@ -39,12 +37,19 @@ on the same machine as the development/compilation was done on. You can find the
 latest versions at https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads
 
 
-Linux
------
+## Linux
 
-You need to ensure that wxGTK is already installed on your machine, under
-Ubuntu these are available from the standard repositories, the version of
-wxWidgets is adequate.
+You need to ensure that wxGTK is already installed on your machine.
+
+Debian, Ubuntu:
+```sh
+sudo apt install libwxgtk3.0-dev
+```
+
+Fedora, CentOS, RedHat:
+```sh
+sudo dnf install wxGTK3-devel
+```
 
 To install them from scratch, you need to get wxGTK from 
 <http://www.wxwidgets.org>. If you do a "make install" on it then they'll
@@ -53,3 +58,27 @@ be installed in the right places and nothing more needs to be done.
 To actually build the software, type "make" in the same directory as this file
 and all should build without errors, there may be a warning or two though. Once
 compiled log in as root or use the sudo command, and do "make install".
+
+You can optionally specify some make variables to alter the default behavior:
+
+| Parameter | Default   | Description                       |
+| --------- | --------- | --------------------------------- |
+| BUILD     | `debug`   | `debug` or `release`              |
+| TARGET    | _not set_ | when set to `opendv`, installs files in legacy locations |
+| DATADIR   | `/usr/share/ircddbgateway` | where AMBE voice and host lists are kept |
+| LOGDIR    | `/var/log` | location of log files            |
+| CONFDIR   | `/etc`     | location of configuration files  |
+| BINDIR    | `/usr/bin` | program binaries installed here  |
+
+### Example
+
+```sh
+cd ircDDBGateway
+make -j4 BUILD=release CONFDIR=/etc/dstar
+sudo make install
+```
+
+This would build and install all the programs in this repo using 4 threads
+(parallel build jobs), in release mode (no debug symbols) with a modified
+configuration directory.
+

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,28 @@
+export BUILD?=debug
 ifeq ($(TARGET), opendv)
-export DATADIR := "/usr/share/opendv"
-export LOGDIR  := "/var/log/opendv"
-export CONFDIR := "/etc"
-export BINDIR  := "/usr/sbin"
+export DATADIR ?= "/usr/share/opendv"
+export LOGDIR  ?= "/var/log/opendv"
+export CONFDIR ?= "/etc"
+export BINDIR  ?= "/usr/sbin"
 else
-export DATADIR := "/usr/share/ircddbgateway"
-export LOGDIR  := "/var/log"
-export CONFDIR := "/etc"
-export BINDIR  := "/usr/bin"
+export DATADIR ?= "/usr/share/ircddbgateway"
+export LOGDIR  ?= "/var/log"
+export CONFDIR ?= "/etc"
+export BINDIR  ?= "/usr/bin"
 endif
 
 # Add -DDCS_LINK to the end of the CFLAGS line below to add DCS linking to StarNet
 # Add -DDEXTRA_LINK to the end of the CFLAGS line below to add DExtra linking to StarNet
 
+DEBUGFLAGS     := -g -D_DEBUG
+RELEASEFLAGS   := -DNDEBUG -DwxDEBUG_LEVEL=0
 export CXX     := $(shell wx-config --cxx)
 export CFLAGS  := -O2 -Wall $(shell wx-config --cxxflags) -DLOG_DIR='$(LOGDIR)' -DCONF_DIR='$(CONFDIR)' -DDATA_DIR='$(DATADIR)'
+ifeq ($(BUILD), debug)
+	export CFLAGS  := $(CFLAGS) $(DEBUGFLAGS)
+else ($(BUILD), release)
+	export CFLAGS  := $(CFLAGS) $(RELEASEFLAGS)
+endif
 export GUILIBS := $(shell wx-config --libs adv,core,base)
 export LIBS    := $(shell wx-config --libs base,net)
 export LDFLAGS := 


### PR DESCRIPTION
Introduces a `BUILD` make parameter to allow for building both debug
and release variants from the same Makefile. This also makes the
Makefile-defined preprocessor macros more in line with those from
Visual Studio build.

Minor changes:
* allows for overwriting LOGDIR, CONFDIR, BINDIR and DATADIR from
  command line (make parameter)
* converts BUILD.txt to Markdown for better visibility on Github
* improves Linux build instructions in BUILD.md