### PR TITLE
Remove ircDDBGatewayConfig from make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ endif
 	$(MAKE) -C TimerControl install
 	$(MAKE) -C TimeServer install
 	$(MAKE) -C VoiceTransmit install
-	$(MAKE) -C ircDDBGatewayConfig install
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Do not attempt to install ircDDBGatewayConfig when using GUI-less
Makefile. ircDDBGatewayConfig is a GUI application and regular
Makefile does not build it.