### PR TITLE
Add support for Gateway CQ linking

### DIFF
--- a/Common/IRCDDBGatewayConfig.cpp
+++ b/Common/IRCDDBGatewayConfig.cpp
@@ -200,6 +200,7 @@ const wxString  KEY_ECHO_ENABLED             = wxT("echoEnabled");
 const wxString  KEY_LOG_ENABLED              = wxT("logEnabled");
 const wxString  KEY_DRATS_ENABLED            = wxT("dratsEnabled");
 const wxString  KEY_DTMF_ENABLED             = wxT("dtmfEnabled");
+const wxString  KEY_GW_CQ_LINK_ENABLED	     = wxT("gatewayCQLinkEnabled");
 const wxString  KEY_GPSD_ENABLED             = wxT("gpsdEnabled");
 const wxString  KEY_GPSD_ADDRESS             = wxT("gpsdAddress");
 const wxString  KEY_GPSD_PORT                = wxT("gpsdPort");
@@ -284,6 +285,7 @@ const bool         DEFAULT_INFO_ENABLED          = true;
 const bool         DEFAULT_ECHO_ENABLED          = true;
 const bool         DEFAULT_DRATS_ENABLED         = false;
 const bool         DEFAULT_DTMF_ENABLED          = true;
+const bool         DEFAULT_GW_CQ_LINK_ENABLED    = false;
 const bool         DEFAULT_GPSD_ENABLED          = false;
 const wxString     DEFAULT_GPSD_ADDRESS          = wxT("127.0.0.1");
 const wxString     DEFAULT_GPSD_PORT             = wxT("2947");
@@ -477,6 +479,7 @@ m_echoEnabled(DEFAULT_ECHO_ENABLED),
 m_logEnabled(DEFAULT_LOG_ENABLED),
 m_dratsEnabled(DEFAULT_DRATS_ENABLED),
 m_dtmfEnabled(DEFAULT_DTMF_ENABLED),
+m_gatewayCQLinkEnabled(DEFAULT_GW_CQ_LINK_ENABLED),
 m_gpsdEnabled(DEFAULT_GPSD_ENABLED),
 m_gpsdAddress(DEFAULT_GPSD_ADDRESS),
 m_gpsdPort(DEFAULT_GPSD_PORT),
@@ -893,6 +896,8 @@ m_y(DEFAULT_WINDOW_Y)
 
 	m_config->Read(m_name + KEY_DTMF_ENABLED, &m_dtmfEnabled, DEFAULT_DTMF_ENABLED);
 
+	m_config->Read(m_name + KEY_GW_CQ_LINK_ENABLED, &m_gatewayCQLinkEnabled, DEFAULT_GW_CQ_LINK_ENABLED);
+
 	m_config->Read(m_name + KEY_GPSD_ENABLED, &m_gpsdEnabled, DEFAULT_GPSD_ENABLED);
 
 	m_config->Read(m_name + KEY_GPSD_ADDRESS, &m_gpsdAddress, DEFAULT_GPSD_ADDRESS);
@@ -1096,6 +1101,7 @@ m_echoEnabled(DEFAULT_ECHO_ENABLED),
 m_logEnabled(DEFAULT_LOG_ENABLED),
 m_dratsEnabled(DEFAULT_DRATS_ENABLED),
 m_dtmfEnabled(DEFAULT_DTMF_ENABLED),
+m_gatewayCQLinkEnabled(DEFAULT_GW_CQ_LINK_ENABLED),
 m_gpsdEnabled(DEFAULT_GPSD_ENABLED),
 m_gpsdAddress(DEFAULT_GPSD_ADDRESS),
 m_gpsdPort(DEFAULT_GPSD_PORT),
@@ -1574,6 +1580,9 @@ m_y(DEFAULT_WINDOW_Y)
 		} else if (key.IsSameAs(KEY_DTMF_ENABLED)) {
 			val.ToLong(&temp1);
 			m_dtmfEnabled = temp1 == 1L;
+		} else if (key.IsSameAs(KEY_GW_CQ_LINK_ENABLED)) {
+			val.ToLong(&temp1);
+			m_gatewayCQLinkEnabled = temp1 == 1L;
 		} else if (key.IsSameAs(KEY_GPSD_ENABLED)) {
 			val.ToLong(&temp1);
 			m_gpsdEnabled = temp1 == 1L;
@@ -2178,7 +2187,7 @@ void CIRCDDBGatewayConfig::setRemote(bool enabled, const wxString& password, uns
 	m_remotePort     = port;
 }
 
-void CIRCDDBGatewayConfig::getMiscellaneous(TEXT_LANG& language, bool& infoEnabled, bool& echoEnabled, bool& logEnabled, bool& dratsEnabled, bool& dtmfEnabled) const
+void CIRCDDBGatewayConfig::getMiscellaneous(TEXT_LANG& language, bool& infoEnabled, bool& echoEnabled, bool& logEnabled, bool& dratsEnabled, bool& dtmfEnabled, bool& gatewayCQLinkEnabled) const
 {
 	language     = m_language;
 	infoEnabled  = m_infoEnabled;
@@ -2186,9 +2195,10 @@ void CIRCDDBGatewayConfig::getMiscellaneous(TEXT_LANG& language, bool& infoEnabl
 	logEnabled   = m_logEnabled;
 	dratsEnabled = m_dratsEnabled;
 	dtmfEnabled  = m_dtmfEnabled;
+	gatewayCQLinkEnabled = m_gatewayCQLinkEnabled;
 }
 
-void CIRCDDBGatewayConfig::setMiscellaneous(TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled)
+void CIRCDDBGatewayConfig::setMiscellaneous(TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled, bool gatewayCQLinkEnabled)
 {
 	m_language     = language;
 	m_infoEnabled  = infoEnabled;
@@ -2196,6 +2206,7 @@ void CIRCDDBGatewayConfig::setMiscellaneous(TEXT_LANG language, bool infoEnabled
 	m_logEnabled   = logEnabled;
 	m_dratsEnabled = dratsEnabled;
 	m_dtmfEnabled  = dtmfEnabled;
+	m_gatewayCQLinkEnabled = gatewayCQLinkEnabled;
 }
 
 void CIRCDDBGatewayConfig::getGPSD(bool& enabled, wxString& address, wxString& port) const
@@ -2450,6 +2461,7 @@ bool CIRCDDBGatewayConfig::write()
 	m_config->Write(m_name + KEY_LOG_ENABLED, m_logEnabled);
 	m_config->Write(m_name + KEY_DRATS_ENABLED, m_dratsEnabled);
 	m_config->Write(m_name + KEY_DTMF_ENABLED, m_dtmfEnabled);
+	m_config->Write(m_name + KEY_GW_CQ_LINK_ENABLED, m_gatewayCQLinkEnabled);
 	m_config->Write(m_name + KEY_GPSD_ENABLED, m_gpsdEnabled);
 	m_config->Write(m_name + KEY_GPSD_ADDRESS, m_gpsdAddress);
 	m_config->Write(m_name + KEY_GPSD_PORT, m_gpsdPort);
@@ -2659,6 +2671,7 @@ bool CIRCDDBGatewayConfig::write()
 	buffer.Printf(wxT("%s=%d"), KEY_LOG_ENABLED.c_str(), m_logEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%d"), KEY_DRATS_ENABLED.c_str(), m_dratsEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%d"), KEY_DTMF_ENABLED.c_str(), m_dtmfEnabled ? 1 : 0); file.AddLine(buffer);
+	buffer.Printf(wxT("%s=%d"), KEY_GW_CQ_LINK_ENABLED.c_str(), m_gatewayCQLinkEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%d"), KEY_GPSD_ENABLED.c_str(), m_gpsdEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_GPSD_ADDRESS.c_str(), m_gpsdAddress.c_str()); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_GPSD_PORT.c_str(), m_gpsdPort.c_str()); file.AddLine(buffer);

--- a/Common/IRCDDBGatewayConfig.h
+++ b/Common/IRCDDBGatewayConfig.h
@@ -109,8 +109,8 @@ public:
 	void getRemote(bool& enabled, wxString& password, unsigned int& port) const;
 	void setRemote(bool enabled, const wxString& password, unsigned int port);
 
-	void getMiscellaneous(TEXT_LANG& language, bool& infoEnabled, bool& echoEnabled, bool& logEnabled, bool& dratsEnabled, bool& dtmfEnabled) const;
-	void setMiscellaneous(TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled);
+	void getMiscellaneous(TEXT_LANG& language, bool& infoEnabled, bool& echoEnabled, bool& logEnabled, bool& dratsEnabled, bool& dtmfEnabled, bool& gatewayCQLinkEnabled) const;
+	void setMiscellaneous(TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled, bool gatewayCQLinkEnabled);
 
 	void getGPSD(bool& enabled, wxString& address, wxString& port) const;
 	void setGPSD(bool enabled, const wxString& address, const wxString& port);
@@ -307,6 +307,7 @@ private:
 	bool          m_logEnabled;
 	bool          m_dratsEnabled;
 	bool          m_dtmfEnabled;
+	bool		  m_gatewayCQLinkEnabled;
 	bool          m_gpsdEnabled;
 	wxString      m_gpsdAddress;
 	wxString      m_gpsdPort;

--- a/Common/IRCDDBGatewayConfig.h
+++ b/Common/IRCDDBGatewayConfig.h
@@ -307,7 +307,7 @@ private:
 	bool          m_logEnabled;
 	bool          m_dratsEnabled;
 	bool          m_dtmfEnabled;
-	bool		  m_gatewayCQLinkEnabled;
+	bool          m_gatewayCQLinkEnabled;
 	bool          m_gpsdEnabled;
 	wxString      m_gpsdAddress;
 	wxString      m_gpsdPort;

--- a/Common/RepeaterHandler.cpp
+++ b/Common/RepeaterHandler.cpp
@@ -52,7 +52,7 @@ bool                      CRepeaterHandler::m_dcsEnabled = true;
 bool                      CRepeaterHandler::m_infoEnabled = true;
 bool                      CRepeaterHandler::m_echoEnabled = true;
 bool                      CRepeaterHandler::m_dtmfEnabled = true;
-bool					  CRepeaterHandler::m_gatewayCQLinkEnabled = false;
+bool                      CRepeaterHandler::m_gatewayCQLinkEnabled = false;
 
 CHeaderLogger*            CRepeaterHandler::m_headerLogger = NULL;
 

--- a/Common/RepeaterHandler.h
+++ b/Common/RepeaterHandler.h
@@ -76,6 +76,7 @@ public:
 	static void setInfoEnabled(bool enabled);
 	static void setEchoEnabled(bool enabled);
 	static void setDTMFEnabled(bool enabled);
+	static void setGatewayCQLinkEnabled(bool enabled);
 	static void setWhiteList(CCallsignList* list);
 	static void setBlackList(CCallsignList* list);
 	static void setRestrictList(CCallsignList* list);
@@ -161,6 +162,7 @@ private:
 	static bool      m_infoEnabled;
 	static bool      m_echoEnabled;
 	static bool      m_dtmfEnabled;
+	static bool		 m_gatewayCQLinkEnabled;
 
 	static CHeaderLogger*   m_headerLogger;
 

--- a/Common/RepeaterHandler.h
+++ b/Common/RepeaterHandler.h
@@ -162,7 +162,7 @@ private:
 	static bool      m_infoEnabled;
 	static bool      m_echoEnabled;
 	static bool      m_dtmfEnabled;
-	static bool		 m_gatewayCQLinkEnabled;
+	static bool      m_gatewayCQLinkEnabled;
 
 	static CHeaderLogger*   m_headerLogger;
 

--- a/ircDDBGateway/IRCDDBGatewayApp.cpp
+++ b/ircDDBGateway/IRCDDBGatewayApp.cpp
@@ -286,9 +286,9 @@ void CIRCDDBGatewayApp::createThread()
 	}
 
 	TEXT_LANG language;
-	bool infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled;
-	m_config->getMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled);
-	wxLogInfo(wxT("Language: %d, info enabled: %d, echo enabled: %d, log enabled : %d, D-RATS enabled: %d, DTMF control enabled: %d"), int(language), int(infoEnabled), int(echoEnabled), int(logEnabled), int(dratsEnabled), int(dtmfEnabled));
+	bool infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled;
+	m_config->getMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled);
+	wxLogInfo(wxT("Language: %d, info enabled: %d, echo enabled: %d, log enabled : %d, D-RATS enabled: %d, DTMF control enabled: %d, Gateway CQ Link enabled: %d"), int(language), int(infoEnabled), int(echoEnabled), int(logEnabled), int(dratsEnabled), int(dtmfEnabled), int(gatewayCQLinkEnabled));
 
 	bool gpsdEnabled;
 	wxString gpsdAddress, gpsdPort;
@@ -964,7 +964,7 @@ void CIRCDDBGatewayApp::createThread()
 	thread->setInfoEnabled(infoEnabled);
 	thread->setEchoEnabled(echoEnabled);
 	thread->setDTMFEnabled(dtmfEnabled);
-	thread->setLog(logEnabled);
+	thread->setGatewayCQLinkEnabled(gatewayCQLinkEnabled);
 	thread->setLocation(latitude, longitude);
 
 	// Convert the worker class into a thread

--- a/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -92,6 +92,7 @@ m_ccsHost(),
 m_infoEnabled(true),
 m_echoEnabled(true),
 m_dtmfEnabled(true),
+m_gatewayCQLinkEnabled(false),
 m_logEnabled(false),
 m_ddModeEnabled(false),
 m_lastStatus(IS_DISABLED),
@@ -287,6 +288,7 @@ void CIRCDDBGatewayThread::run()
 	CRepeaterHandler::setInfoEnabled(m_infoEnabled);
 	CRepeaterHandler::setEchoEnabled(m_echoEnabled);
 	CRepeaterHandler::setDTMFEnabled(m_dtmfEnabled);
+	CRepeaterHandler::setGatewayCQLinkEnabled(m_gatewayCQLinkEnabled);
 	if (m_whiteList != NULL) {
 		CDExtraHandler::setWhiteList(m_whiteList);
 		CDPlusHandler::setWhiteList(m_whiteList);
@@ -637,6 +639,11 @@ void CIRCDDBGatewayThread::setEchoEnabled(bool enabled)
 void CIRCDDBGatewayThread::setDTMFEnabled(bool enabled)
 {
 	m_dtmfEnabled = enabled;
+}
+
+void CIRCDDBGatewayThread::setGatewayCQLinkEnabled(bool enabled)
+{
+	m_gatewayCQLinkEnabled = enabled;
 }
 
 void CIRCDDBGatewayThread::setDDModeEnabled(bool enabled)

--- a/ircDDBGateway/IRCDDBGatewayThread.h
+++ b/ircDDBGateway/IRCDDBGatewayThread.h
@@ -68,6 +68,7 @@ public:
 	virtual void setInfoEnabled(bool enabled);
 	virtual void setEchoEnabled(bool enabled);
 	virtual void setDTMFEnabled(bool enabled);
+	virtual void setGatewayCQLinkEnabled(bool enabled);
 	virtual void setDDModeEnabled(bool enabled);
 	virtual void setRemote(bool enabled, const wxString& password, unsigned int port);
 	virtual void setLocation(double latitude, double longitude);
@@ -115,6 +116,7 @@ private:
 	bool                      m_infoEnabled;
 	bool                      m_echoEnabled;
 	bool                      m_dtmfEnabled;
+	bool                      m_gatewayCQLinkEnabled;
 	bool                      m_logEnabled;
 	bool                      m_ddModeEnabled;
 	IRCDDB_STATUS             m_lastStatus;

--- a/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
+++ b/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
@@ -322,10 +322,10 @@ m_miscellaneous(NULL)
 	noteBook->AddPage(m_gpsd, wxT("GPSD"), false);
 
 	TEXT_LANG language;
-	bool infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled;
-	m_config->getMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled);
+	bool infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled;
+	m_config->getMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled);
 
-	m_miscellaneous = new CIRCDDBGatewayConfigMiscellaneousSet(noteBook, -1, APPLICATION_NAME, language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled);
+	m_miscellaneous = new CIRCDDBGatewayConfigMiscellaneousSet(noteBook, -1, APPLICATION_NAME, language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled);
 	noteBook->AddPage(m_miscellaneous, wxT("Misc"), false);
 
 	sizer->Add(noteBook, 0, wxEXPAND | wxALL, BORDER_SIZE);
@@ -622,7 +622,8 @@ void CIRCDDBGatewayConfigFrame::onSave(wxCommandEvent&)
 	bool logEnabled    = m_miscellaneous->getLogEnabled();
 	bool dratsEnabled  = m_miscellaneous->getDRATSEnabled();
 	bool dtmfEnabled   = m_miscellaneous->getDTMFEnabled();
-	m_config->setMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled);
+	bool gatewayCQLinkEnabled = m_miscellaneous->getGatewayCQLinkEnabled();
+	m_config->setMiscellaneous(language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled, gatewayCQLinkEnabled);
 
 	bool ret = m_config->write();
 	if (!ret) {

--- a/ircDDBGatewayConfig/IRCDDBGatewayConfigMiscellaneousSet.cpp
+++ b/ircDDBGatewayConfig/IRCDDBGatewayConfigMiscellaneousSet.cpp
@@ -23,7 +23,7 @@ const unsigned int CONTROL_WIDTH = 130U;
 
 const unsigned int BORDER_SIZE = 5U;
 
-CIRCDDBGatewayConfigMiscellaneousSet::CIRCDDBGatewayConfigMiscellaneousSet(wxWindow* parent, int id, const wxString& title, TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled) :
+CIRCDDBGatewayConfigMiscellaneousSet::CIRCDDBGatewayConfigMiscellaneousSet(wxWindow* parent, int id, const wxString& title, TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled, bool gatewayCQLinkEnabled) :
 wxPanel(parent, id),
 m_title(title),
 m_language(NULL),
@@ -31,6 +31,7 @@ m_infoEnabled(NULL),
 m_echoEnabled(NULL),
 m_logEnabled(NULL),
 m_dratsEnabled(NULL),
+m_gatewayCQLinkEnabled(NULL),
 m_dtmfEnabled(NULL)
 {
 	wxFlexGridSizer* sizer = new wxFlexGridSizer(2);
@@ -99,6 +100,12 @@ m_dtmfEnabled(NULL)
 	m_dtmfEnabled->Append(_("Enabled"));
 	sizer->Add(m_dtmfEnabled, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
 	m_dtmfEnabled->SetSelection(dtmfEnabled ? 1 : 0);
+
+	m_gatewayCQLinkEnabled = new wxChoice(this, -1, wxDefaultPosition, wxSize(CONTROL_WIDTH, -1));
+	m_gatewayCQLinkEnabled->Append(_("Disabled"));
+	m_gatewayCQLinkEnabled->Append(_("Enabled"));
+	sizer->Add(m_gatewayCQLinkEnabled, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
+	m_gatewayCQLinkEnabled->SetSelection(gatewayCQLinkEnabled ? 1 : 0);
 
 	SetAutoLayout(true);
 
@@ -178,6 +185,15 @@ bool CIRCDDBGatewayConfigMiscellaneousSet::getDRATSEnabled() const
 bool CIRCDDBGatewayConfigMiscellaneousSet::getDTMFEnabled() const
 {
 	int c = m_dtmfEnabled->GetCurrentSelection();
+	if (c == wxNOT_FOUND)
+		return false;
+
+	return c == 1;
+}
+
+bool CIRCDDBGatewayConfigMiscellaneousSet::getGatewayCQLinkEnabled() const
+{
+	int c = m_gatewayCQLinkEnabled->GetCurrentSelection();
 	if (c == wxNOT_FOUND)
 		return false;
 

--- a/ircDDBGatewayConfig/IRCDDBGatewayConfigMiscellaneousSet.h
+++ b/ircDDBGatewayConfig/IRCDDBGatewayConfigMiscellaneousSet.h
@@ -25,7 +25,7 @@
 
 class CIRCDDBGatewayConfigMiscellaneousSet : public wxPanel {
 public:
-	CIRCDDBGatewayConfigMiscellaneousSet(wxWindow* parent, int id, const wxString& title, TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled);
+	CIRCDDBGatewayConfigMiscellaneousSet(wxWindow* parent, int id, const wxString& title, TEXT_LANG language, bool infoEnabled, bool echoEnabled, bool logEnabled, bool dratsEnabled, bool dtmfEnabled, bool gatewayCQLinkEnabled);
 	virtual ~CIRCDDBGatewayConfigMiscellaneousSet();
 
 	virtual bool Validate();
@@ -42,6 +42,8 @@ public:
 
 	virtual bool      getDTMFEnabled() const;
 
+	virtual bool      getGatewayCQLinkEnabled() const;
+
 private:
 	wxString  m_title;
 	wxChoice* m_language;
@@ -50,6 +52,7 @@ private:
 	wxChoice* m_logEnabled;
 	wxChoice* m_dratsEnabled;
 	wxChoice* m_dtmfEnabled;
+	wxChoice* m_gatewayCQLinkEnabled;
 };
 
 #endif


### PR DESCRIPTION
This may be a debated PR...

The Icom/Kenwood transceivers provide DR capabilities and allow for "GatewayCQ". G2 doesn't appear compatible with QuadNet, and linking appears not possible through Pi-Star hotspots.. 

This change effectively translates the G2 repeater link requests into UR linking requests to a repeater. 

`/1234567` -> `1234567L` 

This may cause disruption if keyed into a busy repeater. 

It's toggled by config prop `gatewayCQLinkEnabled`. Defaulted `false`

I'd like to get some opinions on this type of change. I've read that OpenSpot provides this type of capability. 

-Dan
N1TSX