### PR TITLE
Add setup documentation and Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ uninstall:
 ifeq ($(TARGET), opendv)
 	userdel opendv || true
 	rm -r /var/log/opendv || true
+	rm $(DESTDIR)/etc/systemd/system/ircddbgatewayd.service
 endif
 	rm -r $(DESTDIR)$(DATADIR) || true
 	rm $(DESTDIR)$(BINDIR)/aprstransmitd || true

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,22 @@ clean:
 	$(MAKE) -C VoiceTransmit clean
 	$(MAKE) -C ircDDBGatewayConfig clean
 
+.PHONY: uninstall
+uninstall:
+ifeq ($(TARGET), opendv)
+	userdel opendv || true
+	rm -r /var/log/opendv || true
+endif
+	rm -r $(DESTDIR)$(DATADIR) || true
+	rm $(DESTDIR)$(BINDIR)/aprstransmitd || true
+	rm $(DESTDIR)$(BINDIR)/ircddbgatewayd || true
+	rm $(DESTDIR)$(BINDIR)/remotecontrold || true
+	rm $(DESTDIR)$(BINDIR)/starnetserverd || true
+	rm $(DESTDIR)$(BINDIR)/texttransmitd || true
+	rm $(DESTDIR)$(BINDIR)/timercontrold || true
+	rm $(DESTDIR)$(BINDIR)/timeserverd || true
+	@echo "*** NOTE: Leaving /etc/ircddbgateway in place ***"
+
 .PHONY: force
 force :
 	@true

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ Now you should edit the configuration in the file /etc/ircddbgateway to match yo
 
 When building in TARGET=opendv mode, the necessary systemd unit files will be installed. To ensure ircddbgatewayd starts at system boot, and then immediately start it, use:
 ```shell
-sudo systemctl enable ircddbgatewayd.service #enable service
+sudo systemctl enable ircddbgatewayd.service
 sudo service ircddbgatewayd start
 ```
 
-If you wish to remove the manually installed files you may use `sudo make uninstall`
+If you wish to remove the manually installed files you may use `sudo make uninstall`.
+Note that this will remove the systemd unit, but will not first stop or disable the service. To do so, first use:
+```shell
+sudo systemctl disable --now ircddbgateway.service
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ make
 make -f MakefileGUI #only required if you want to build the GUI programs
 sudo make install
 ```
+Note that you may need to use `sudo -E make install` to pass the environment variables, or just `sudo TARGET=opendv make install` to correctly create the opendv user/directories, depending on your system configuration.
+
 Now you should edit the configuration in the file /etc/ircddbgateway to match your needs.
+
+When building in TARGET=opendv mode, the necessary systemd unit files will be installed. To ensure ircddbgatewayd starts at system boot, and then immediately start it, use:
 ```shell
 sudo systemctl enable ircddbgatewayd.service #enable service
 sudo service ircddbgatewayd start

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ When building in TARGET=opendv mode, the necessary systemd unit files will be in
 sudo systemctl enable ircddbgatewayd.service #enable service
 sudo service ircddbgatewayd start
 ```
+
+If you wish to remove the manually installed files you may use `sudo make uninstall`

--- a/README.md
+++ b/README.md
@@ -53,3 +53,28 @@ Note that this will remove the systemd unit, but will not first stop or disable 
 ```shell
 sudo systemctl disable --now ircddbgateway.service
 ```
+It will also not remove your /etc/ircddbgateway configuration file.
+
+# Setup
+
+Only the ircddbgatewayd service is required for basic usage, all other compiled applications are optional.
+
+## ICOM repeater configuration
+If using an ICOM ID-RP2C you will need to use the ICOM utility to configure the repeater. By default the ID-RP2C uses the IP address 172.16.0.1, and expects the device controlling it (either your computer, or the computer running ircddbgatewayd) to be using the IP address 172.16.0.20, and uses the default password "PASSWORD". It may not be advisable to change this password as performing a hardware reset is not a documented feature. Ideally the ID-RP2C is connected directly to a secondary ethernet port on the device running ircddbgatewayd and configured with a static IP address, other configurations may prove problematic.
+
+When configuring the repeater using the ICOM utility you will need to change the port in the "Communication Settings" section to use the same port as is used in the "Gateway" section (20000 by default), and then go into the Options/Network Setup menu of the ICOM app to change the port to match what you put into the "Communication Settings" section.
+
+Once both of those fields are set to the same port number, ensure that the "Local RPT" section is set correctly for whichever physical plug your ID-RP2D is plugged into on the back of the ID-RP2C. Whichever number you have plugged in to should be set to "Voice", and have the correct band entered in the text box. ("B" for 70cm, for example.)
+
+In your /etc/ircddbgateway config file the following options are important:
+```
+icomAddress=172.16.0.20
+icomPort=20000
+repeaterCall1=REPEATERCALLSIGN
+repeaterBand1=B
+repeaterType1=1
+repeaterAddress=172.16.0.1
+repeaterPort1=20000
+```
+Note that this assumes you're configuring "Repeater 1".
+The repeaterAdress is the address of the ID-RP2C controller, and "icomAddress" is the address of the device running ircddbgatewayd. The "Type" being 1 indicates an ICOM repeater. The Band should be set to whichever band you entered in the "Local RPT" section of the ICOM configuration software, and the callsign should match the call used in in the ICOM software.

--- a/ircDDBGateway/Makefile
+++ b/ircDDBGateway/Makefile
@@ -15,7 +15,9 @@ ircddbgatewayd:	$(OBJECTS) ../ircDDB/IRCDDB.a ../Common/Common.a
 .PHONY: install
 install:
 		install -g root -o root -m 0755 ircddbgatewayd $(DESTDIR)$(BINDIR)
+ifeq (,$(wildcard $(DESTDIR)$(CONFDIR)/ircddbgateway))
 		cp ircddbgateway-emptyconfig $(DESTDIR)$(CONFDIR)/ircddbgateway
+endif
 ifeq ($(TARGET), opendv)
 		cp ../debian/ircddbgatewayd.ircddbgatewayd.service $(DESTDIR)/etc/systemd/system/ircddbgatewayd.service
 endif


### PR DESCRIPTION
This PR is the result of my first attempt at setting up ircDDBGateway to work with an ICOM repeater, as a total newbie to both.

I fixes two minor pain points I experienced with the Makefile:
1) clobbering existing config file with empty default at every make install
2) Inability to cleanly remove installed files

In addition it adds some documentation to the process:
1) Documents an issue where TARGET=opendv may not get passed to make install
2) Documents the systemd unit setup resulting from TARGET=opendv a bit more
3) Documents the configuration required, to the best of my understanding, to get things to work with an ID-RP2C repeater. 

Things to note:
1) This is completely un-tested on any platform other than (debian-based) linux. Since I only changed the Makefile I don't expect that there are problems on other platforms, but I cannot be sure. I am also not a Makefile wizard, so while I tested it and it does what I want it to do, someone more experienced with Makefiles reviewing it would be much appreciated.
2) As mentioned before, I'm a complete newbie to ircDDBGateway, the ID-RP2C, and DStar itself... So it would be nice to sanity-check anything I said in the README. I have merely documented what things I needed to do and found conflicting information online for while getting our club setup to a basic working state.

If you would like me to split this PR into multiple PRs for documentation and Makefile changes, or remove anything from it, please let me know!