### PR TITLE
Small debug/non-debug build cleanup.

### DIFF
--- a/Common/Version.h
+++ b/Common/Version.h
@@ -23,10 +23,10 @@
 
 const wxString VENDOR_NAME = wxT("G4KLX");
 
-#if defined(__WXDEBUG__)
+#if defined(_DEBUG)
 const wxString VERSION = wxT("20200621 - DEBUG");
 #else
-const wxString VERSION = wxT("20190621");
+const wxString VERSION = wxT("20200621");
 #endif
 
 #endif


### PR DESCRIPTION
Don't rely to \_\_WXDEBUG\_\_, as once wx/debug is included, it's defined, despite setting wxDEBUG_LEVEL=0.
Fix non-debug build date (matching debug one).
